### PR TITLE
[RFR] Add "Download JSON report" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ d3.json("reports/report.xml", function(err, data) {
         .call(chart);
 });
 ```
+
+If you want to display a single report (for instance, on your project page), you do not need the `ReportTransformer`. Simply download the converted JSON report from the [GitHub page](http://marmelab.com/phpunit-d3-report/), just under the chart. Then, you can query directly the report, skipping the transformation process, and thus optimizing performances.
+
+``` js
+d3.json("reports/phpunit-d3-report.json", function(err, data) {
+    d3.select("#bubbles").datum(data).call(chart);
+});
+```
+
 ### Parameters
 
 If you want to customize the output report, several paramaters are available as functions, following the [Mike Bostock's re-usable chart pattern]. For instance, if you want to modify the padding of each bubble, use:

--- a/index.html
+++ b/index.html
@@ -13,8 +13,11 @@
             <p class="lead">This visualization tool provides a quick way to monitor your PHPUnit test suites. With a single glance, you will be able to identify the slowest tests, helping you to improve the overall execution time of your tests.</p>
 
             <p id="sample_introduction">Here is a sample of report this utility can generate. It is based on <a href="https://github.com/symfony/symfony/tree/2.3">Symfony 2.3</a> test suite:</p>
-            <div id="bubbles">
-            </div>
+
+            <div id="bubbles"></div>
+            <p class="text-right">
+                <a href="#" id="json_report_download_link">Download JSON report</a>
+            </p>
 
             <h2>How to generate your own report?</h2>
             <p>To generate a report, simply execute your PHPUnit test suite including the <code>--log-junit</code> argument, such as:</p>

--- a/js/bubbles.js
+++ b/js/bubbles.js
@@ -1,7 +1,14 @@
+// Compatibility tweaks
+window.URL = window.URL || window.webkitURL;
+
+// Global variables
 var chart = d3.chart.phpunitBubbles().padding(2);
+var jsonReport = null;
 
 // Load Symfony2 test suite sample
 d3.json("reports/symfony2.json", function(err, data) {
+    jsonReport = data;
+
     d3.select("#bubbles")
         .datum(data)
         .call(chart);
@@ -14,10 +21,10 @@ document.getElementById("report_form").addEventListener("submit", function(e) {
     document.getElementById("sample_introduction").innerText = "Here is your custom report:";
 
     var report = document.getElementById("report").value;
-    data = ReportTransformer.transform(report);
+    jsonReport = ReportTransformer.transform(report);
 
     d3.select("#bubbles")
-        .datum(data)
+        .datum(jsonReport)
         .call(chart);
 
     window.scrollTo(0);
@@ -28,3 +35,12 @@ d3.select("body")
     .append("div")
     .attr("class", "tooltip")
     .style("opacity", 0);
+
+// Authorize JSON report download (for external embedding)
+document.getElementById("json_report_download_link").addEventListener("click", function(e) {
+    var blob = new Blob([JSON.stringify(jsonReport)]);
+    var url =window.URL.createObjectURL(blob);
+
+    this.href = url;
+    this.download = 'phpunit-d3-report.json';
+});


### PR DESCRIPTION
For embedding the chart of a given report without recomputing it each time, we can use the transformer JSON report directly, without calling the `ReportTransformer.transform` method. Thanks to the JavaScript `Blob` object, we can force the download of the file to the end-user directly.

![download-report](https://f.cloud.github.com/assets/688373/1895783/cec6db8a-7b5d-11e3-823c-530e52735fd6.gif)
